### PR TITLE
Issue #49 Fixed Flaky Test

### DIFF
--- a/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
+++ b/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
@@ -24,12 +24,13 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -165,7 +166,7 @@ public class ProcessingKafkaConsumer<K, V> implements Closeable {
     /**
      * Maintains the state of all the partitions our consumer is assigned to
      */
-    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = new ConcurrentHashMap<>();
+    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = Collections.synchronizedMap(new LinkedHashMap<>());
 
     /**
      * The partition to process from next

--- a/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
+++ b/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
@@ -1170,7 +1170,7 @@ public class ProcessingKafkaConsumerTest {
         TopicPartition newPartition = new TopicPartition("new-topic", 0);
         when(consumer.committed(newPartition)).thenReturn(new OffsetAndMetadata(0L));
         processingConsumer.rebalanceListener.onPartitionsAssigned(Arrays.asList(topicPartition, newPartition));
-        assertThat(processingConsumer.partitions.keySet(), contains(newPartition, topicPartition));
+        assertThat(processingConsumer.partitions.keySet(), contains(topicPartition, newPartition));
         assertThat(ProcessingKafkaConsumer.REBALANCE_COUNTER.count(), is(rebalanceCount + 1));
     }
 


### PR DESCRIPTION
Tests in the nextRecord_fairProcessing() and rebalanceListener_onPartitionsAssigned() under ProcessingKafkaConsumerTest express non-deterministic behavior. The fix is changing ConcurrentHashMap to Collections.synchronizedMap to ensure deterministic behavior and changing the order of TopicPartition objects.